### PR TITLE
Remove redundant line in wagtailadmin_tags.py

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -484,7 +484,6 @@ def page_listing_buttons(context, page, user):
 
     buttons.sort()
 
-    page_perms = page.permissions_for_user(user)
     for hook in hooks.get_hooks("construct_page_listing_buttons"):
         if accepts_kwarg(hook, "user"):
             hook(buttons, page=page, user=user, context=context)


### PR DESCRIPTION
I was looking at Wagtail's code in my IDE, and noticed that it was claiming the `page_perms` from this line was unused. Turns out it is, as `page_perms` gets reassigned on line 499, before it gets used on line 500. Looks like this is probably a leftover line from an earlier version of the function.